### PR TITLE
:bug: Fix Get-FSCPSAzureStorageFile

### DIFF
--- a/fscps.tools/functions/get-fscpsazurestoragefile.ps1
+++ b/fscps.tools/functions/get-fscpsazurestoragefile.ps1
@@ -113,7 +113,7 @@ function Get-FSCPSAzureStorageFile {
     }
 
     try {
-        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | Sort-Object -Descending { $_.Properties.LastModified }
+        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | Sort-Object -Descending { $_.LastModified }
 
         if ($Latest) {
             $files | Select-Object -First 1 | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }

--- a/fscps.tools/functions/get-fscpsazurestoragefile.ps1
+++ b/fscps.tools/functions/get-fscpsazurestoragefile.ps1
@@ -116,7 +116,7 @@ function Get-FSCPSAzureStorageFile {
         $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | Sort-Object -Descending { $_.LastModified }
 
         if ($Latest) {
-            $files | Select-Object -First 1 | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }
+            $files | Select-Object -First 1 | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { $_.LastModified.UtcDateTime } }
         }
         else {
     
@@ -128,11 +128,11 @@ function Get-FSCPSAzureStorageFile {
                     $null = Test-PathExists -Path $DestinationPath -Type Container -Create
                     $destinationBlobPath = (Join-Path $DestinationPath ($obj.Name))
                     Get-AzStorageBlobContent -Context $storageContext -Container $($Container.ToLower()) -Blob $obj.Name -Destination ($destinationBlobPath) -ConcurrentTaskCount 10 -Force
-                    $obj | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "Path"; Expression = { [string]$destinationBlobPath } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }
+                    $obj | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "Path"; Expression = { [string]$destinationBlobPath } }, @{Name = "LastModified"; Expression = { $_.LastModified.UtcDateTime } }
                 }
                 else
                 {
-                    $obj | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }
+                    $obj | Select-PSFObject -TypeName FSCPS.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { $_.LastModified.UtcDateTime } }
                 }
                 
                 

--- a/fscps.tools/functions/get-fscpsazurestoragefile.ps1
+++ b/fscps.tools/functions/get-fscpsazurestoragefile.ps1
@@ -65,7 +65,28 @@
     .NOTES
         Tags: Azure, Azure Storage, Token, Blob, File, Container
         
-        This is refactored function from d365fo.tools
+        This is refactored function from d365fo.tools (https://github.com/d365collaborative/d365fo.tools) under the
+        MIT License
+
+        Copyright (c) 2018 Mötz Jensen & Rasmus Andersen
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
         
         Original Author: Mötz Jensen (@Splaxi)
         Author: Oleksandr Nikolaiev (@onikolaiev)


### PR DESCRIPTION
While working with `Get-FSCPSAzureStorageFile`, I noticed that the sorting is incorrect on my environment with German localization. The changes in the pr should fix that.

I also added an example to the documentation on how the command can be used to download the files as well.

I'm also wondering what the long term plan for the d365fo.tools dependency is. If the plan is to remove it (which I understand, since d365fo.tools has a lot of stuff not needed by fscps.tools) or make changes easier+faster, I understand the current approach of copying commands from d365fo.tools and refactoring them. If d365fo.tools is here to stay, I would suggest instead of copying commands to simply wrap their d365fo.tools counterpart in a thin wrapper that basically just calls the d365fo.tools command and adds what d365fo.tools does not provide. If that is of interest, let me know and I can provide an example on how this would look like for this command.