### PR TITLE
Refactor invoke fscpsazurestorageupload and fix/improve media type determination

### DIFF
--- a/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
+++ b/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
@@ -78,16 +78,12 @@
 function Invoke-FSCPSAzureStorageUpload {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $false)]
         [string] $AccountId = $Script:AzureStorageAccountId,
 
-        [Parameter(Mandatory = $false)]
         [string] $AccessToken = $Script:AzureStorageAccessToken,
 
-        [Parameter(Mandatory = $false)]
         [string] $SAS = $Script:AzureStorageSAS,
 
-        [Parameter(Mandatory = $false)]
         [Alias('Blob')]
         [Alias('Blobname')]
         [string] $Container = $Script:AzureStorageContainer,
@@ -98,11 +94,10 @@ function Invoke-FSCPSAzureStorageUpload {
         [Alias('Path')]
         [string] $Filepath,
 
-        [Parameter(Mandatory = $false)]
         [string] $ContentType,
 
         [switch] $Force,
-        [Parameter(Mandatory = $false)]
+
         [switch] $DeleteOnUpload,
 
         [switch] $EnableException

--- a/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
+++ b/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
@@ -103,22 +103,24 @@ function Invoke-FSCPSAzureStorageUpload {
         [switch] $EnableException
     )
 
-    if (Test-PSFFunctionInterrupt) { return }
+    PROCESS {
+        if (Test-PSFFunctionInterrupt) { return }
 
-    Invoke-TimeSignal -Start
-    try {
-        if ([string]::IsNullOrEmpty($ContentType)) {
-            $FileName = Split-Path -Path $Filepath -Leaf
-            $ContentType = Get-MediaTypeByFilename $FileName
+        Invoke-TimeSignal -Start
+        try {
+            if ([string]::IsNullOrEmpty($ContentType)) {
+                $FileName = Split-Path -Path $Filepath -Leaf
+                $ContentType = Get-MediaTypeByFilename $FileName
 
-            Write-PSFMessage -Level Verbose -Message "Content Type is automatically set to value: $ContentType"
+                Write-PSFMessage -Level Verbose -Message "Content Type is automatically set to value: $ContentType"
+            }
+            $params = Get-ParameterValue
+            $params["ContentType"] = $ContentType
+
+            Invoke-D365AzureStorageUpload @params
         }
-        $params = Get-ParameterValue
-        $params["ContentType"] = $ContentType
-
-        Invoke-D365AzureStorageUpload @params
-    }
-    finally {
-        Invoke-TimeSignal -End
+        finally {
+            Invoke-TimeSignal -End
+        }
     }
 }

--- a/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
+++ b/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
@@ -2,78 +2,78 @@
 <#
     .SYNOPSIS
         Upload a file to Azure
-        
+
     .DESCRIPTION
         Upload any file to an Azure Storage Account
-        
+
     .PARAMETER AccountId
         Storage Account Name / Storage Account Id where you want to store the file
-        
+
     .PARAMETER AccessToken
         The token that has the needed permissions for the upload action
-        
+
     .PARAMETER SAS
         The SAS key that you have created for the storage account or blob container
-        
+
     .PARAMETER Container
         Name of the blob container inside the storage account you want to store the file
-        
+
     .PARAMETER Filepath
         Path to the file you want to upload
-        
+
     .PARAMETER ContentType
         Media type of the file that is going to be uploaded
-        
+
         The value will be used for the blob property "Content Type".
         If the parameter is left empty, the commandlet will try to automatically determined the value based on the file's extension.
         If the parameter is left empty and the value cannot be automatically be determined, Azure storage will automatically assign "application/octet-stream" as the content type.
         Valid media type values can be found here: https://www.iana.org/assignments/media-types/media-types.xhtml
-        
+
     .PARAMETER Force
         Instruct the cmdlet to overwrite the file in the container if it already exists
-        
+
     .PARAMETER DeleteOnUpload
         Switch to tell the cmdlet if you want the local file to be deleted after the upload completes
-        
+
     .PARAMETER EnableException
         This parameters disables user-friendly warnings and enables the throwing of exceptions
         This is less user friendly, but allows catching exceptions in calling scripts
-        
+
     .EXAMPLE
         PS C:\> Invoke-FSCPSAzureStorageUpload -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles" -Filepath "c:\temp\bacpac\UAT_20180701.bacpac"  -DeleteOnUpload
-        
+
         This will upload the "c:\temp\bacpac\UAT_20180701.bacpac" up to the "backupfiles" container, inside the "miscfiles" Azure Storage Account that is access with the "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" token.
         After upload the local file will be deleted.
-        
+
     .EXAMPLE
         PS C:\> $AzureParams = Get-D365ActiveAzureStorageConfig
         PS C:\> New-D365Bacpac | Invoke-FSCPSAzureStorageUpload @AzureParams
-        
+
         This will get the current Azure Storage Account configuration details and use them as parameters to upload the file to an Azure Storage Account.
-        
+
     .EXAMPLE
         PS C:\> New-D365Bacpac | Invoke-FSCPSAzureStorageUpload
-        
+
         This will generate a new bacpac file using the "New-D365Bacpac" cmdlet.
         The file will be uploaded to an Azure Storage Account using the "Invoke-FSCPSAzureStorageUpload" cmdlet.
         This will use the default parameter values that are based on the configuration stored inside "Get-D365ActiveAzureStorageConfig" for the "Invoke-FSCPSAzureStorageUpload" cmdlet.
-        
+
     .EXAMPLE
         PS C:\> Invoke-FSCPSAzureStorageUpload -AccountId "miscfiles" -SAS "sv2018-03-28&siunlisted&src&sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk" -Container "backupfiles" -Filepath "c:\temp\bacpac\UAT_20180701.bacpac"
-        
+
         This will upload the "c:\temp\bacpac\UAT_20180701.bacpac" up to the "backupfiles" container, inside the "miscfiles" Azure Storage Account.
         A SAS key is used to gain access to the container and uploading the file to it.
-        
+
     .NOTES
         Tags: Azure, Azure Storage, Config, Configuration, Token, Blob, File, Files, Bacpac, Container
-        
+
         This is refactored function from d365fo.tools
-        
+
         Original Author: Mötz Jensen (@Splaxi)
         Author: Oleksandr Nikolaiev (@onikolaiev)
-        
+
         The cmdlet supports piping and can be used in advanced scenarios. See more on github and the wiki pages.
-        
+
 #>
 function Invoke-FSCPSAzureStorageUpload {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -133,7 +133,7 @@ function Invoke-FSCPSAzureStorageUpload {
                 $conString = $("BlobEndpoint=https://{0}.blob.core.windows.net/;QueueEndpoint=https://{0}.queue.core.windows.net/;FileEndpoint=https://{0}.file.core.windows.net/;TableEndpoint=https://{0}.table.core.windows.net/;SharedAccessSignature={1}" -f $AccountId.ToLower(), $SAS)
 
                 Write-PSFMessage -Level Verbose -Message "Working against Azure Storage Account with SAS" -Target $conString
-                
+
                 $storageContext = New-AzStorageContext -ConnectionString $conString
             }
 

--- a/fscps.tools/internal/configurations/configuration.ps1
+++ b/fscps.tools/internal/configurations/configuration.ps1
@@ -16,8 +16,9 @@ Set-PSFConfig -Module 'fscps.tools' -Name 'Import.IndividualFiles' -Value $false
 
 Set-PSFConfig -FullName "fscps.tools.path.azcopy" -Value "C:\temp\fscps.tools\AzCopy\AzCopy.exe" -Initialize -Description "Path to the default location where AzCopy.exe is located."
 Set-PSFConfig -FullName "fscps.tools.path.nuget" -Value "C:\temp\fscps.tools\nuget\nuget.exe" -Initialize -Description "Path to the default location where nuget.exe is located."
+Set-PSFConfig -FullName "fscps.tools.path.mediatypes" -Value "C:\temp\fscps.tools\mediatypes\mediatypes.json" -Initialize -Description "Path to the default location where the media types file is located."
 Set-PSFConfig -FullName 'fscps.tools.settings.github.templateUrl' -Value 'https://github.com/ciellosinc/FSC-PS-Template' -Initialize -Description ''
-Set-PSFConfig -FullName 'fscps.tools.settings.github.templateBranch' -Value 'main' -Initialize -Description '' 
+Set-PSFConfig -FullName 'fscps.tools.settings.github.templateBranch' -Value 'main' -Initialize -Description ''
 
 Set-PSFConfig -FullName "fscps.tools.path.sqlpackage" -Value "C:\Program Files (x86)\Microsoft SQL Server\140\DAC\bin\SqlPackage.exe" -Initialize -Description "Path to the default location where SqlPackage.exe is located."
 Set-PSFConfig -FullName "fscps.tools.azure.common.oauth.token" -Value "https://login.microsoftonline.com/common/oauth2/token" -Initialize -Description "URI / URL for the Azure Active Directory OAuth 2.0 endpoint for tokens"

--- a/fscps.tools/internal/functions/get-mediafiletypebyfilename.ps1
+++ b/fscps.tools/internal/functions/get-mediafiletypebyfilename.ps1
@@ -21,33 +21,33 @@
         Author: Florian Hopfner (@FH-Inway)
 #>
 function Get-MediaTypeByFilename {
-  [CmdletBinding()]
-  param(
-    [Parameter(Mandatory, ValueFromPipeline)]
-    [string[]] $Filename
-  )
-  begin {
-    # Download and parse the list of media types (MIME types) via
-    # https://github.com/jshttp/mime-db.
-    # NOTE:
-    #  * For better performance consider caching the JSON file.
-    #  * A fixed release is targeted, to ensure that future changes to the JSON
-    #    format do not break the command.
-    $mediaTypes = (
-      Invoke-RestMethod https://cdn.jsdelivr.net/gh/jshttp/mime-db@v1.53.0/db.json
-    ).psobject.Properties
-  }
-  process {
-    foreach ($name in $Filename) {
-      # Find the matching media type by filename extension.
-      $matchingMediaType =
-        $mediaTypes.Where(
-          { $_.Value.extensions -contains [IO.Path]::GetExtension($name).Substring(1) },
-          'First'
-        ).Name
-      # Use a fallback type, if no match was found.
-      if (-not $matchingMediaType) { $matchingMediaType = 'application/octet-stream' }
-      $matchingMediaType # output
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string[]] $Filename
+    )
+    begin {
+        # Download and parse the list of media types (MIME types) via
+        # https://github.com/jshttp/mime-db.
+        # NOTE: A fixed release is targeted, to ensure that future changes to the JSON format do not break the command.
+        if (-not (Test-PathExists -Path $Script:MediaTypesPath -Type Leaf -WarningAction SilentlyContinue)) {
+            $mediaTypesFolder = Split-Path -Path $Script:MediaTypesPath -Parent
+            $null = Test-PathExists -Path $mediaTypesFolder -Type Container -Create
+            Invoke-RestMethod -Uri https://cdn.jsdelivr.net/gh/jshttp/mime-db@v1.53.0/db.json -OutFile $Script:MediaTypesPath
+        }
+        $mediaTypes = (Get-Content -Path $Script:MediaTypesPath | ConvertFrom-Json).psobject.Properties
     }
-  }
+    process {
+        foreach ($name in $Filename) {
+            # Find the matching media type by filename extension.
+            $matchingMediaType =
+                $mediaTypes.Where(
+                    { $_.Value.extensions -contains [IO.Path]::GetExtension($name).Substring(1) },
+                    'First'
+                ).Name
+            # Use a fallback type, if no match was found.
+            if (-not $matchingMediaType) { $matchingMediaType = 'application/octet-stream' }
+            $matchingMediaType # output
+        }
+    }
 }

--- a/fscps.tools/internal/functions/get-mediafiletypebyfilename.ps1
+++ b/fscps.tools/internal/functions/get-mediafiletypebyfilename.ps1
@@ -1,3 +1,25 @@
+<#
+    .SYNOPSIS
+        Get the media type (MIME type) of a file based on its filename extension.
+
+    .DESCRIPTION
+        This commandlet retrieves the media type (MIME type) of a file based on its filename extension.
+        The media type is determined by matching the extension to the list of media types (MIME types) from the MIME database https://github.com/jshttp/mime-db
+
+    .PARAMETER Filename
+        The filename(s) for which to determine the media type.
+
+    .EXAMPLE
+        PS C:\> Get-MediaTypeByFilename -Filename 'example.jpg'
+
+        This will return 'image/jpeg' as the media type for the file 'example.jpg'.
+
+    .NOTES
+        Tags: Media type, MIME type, File extension, Filename
+
+        Author: Oleksandr Nikolaiev (@onikolaiev)
+        Author: Florian Hopfner (@FH-Inway)
+#>
 function Get-MediaTypeByFilename {
   [CmdletBinding()]
   param(

--- a/fscps.tools/internal/functions/get-mediafiletypebyfilename.ps1
+++ b/fscps.tools/internal/functions/get-mediafiletypebyfilename.ps1
@@ -1,0 +1,31 @@
+function Get-MediaTypeByFilename {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory, ValueFromPipeline)]
+    [string[]] $Filename
+  )
+  begin {
+    # Download and parse the list of media types (MIME types) via
+    # https://github.com/jshttp/mime-db.
+    # NOTE:
+    #  * For better performance consider caching the JSON file.
+    #  * A fixed release is targeted, to ensure that future changes to the JSON
+    #    format do not break the command.
+    $mediaTypes = (
+      Invoke-RestMethod https://cdn.jsdelivr.net/gh/jshttp/mime-db@v1.53.0/db.json
+    ).psobject.Properties
+  }
+  process {
+    foreach ($name in $Filename) {
+      # Find the matching media type by filename extension.
+      $matchingMediaType =
+        $mediaTypes.Where(
+          { $_.Value.extensions -contains [IO.Path]::GetExtension($name).Substring(1) },
+          'First'
+        ).Name
+      # Use a fallback type, if no match was found.
+      if (-not $matchingMediaType) { $matchingMediaType = 'application/octet-stream' }
+      $matchingMediaType # output
+    }
+  }
+}

--- a/fscps.tools/internal/scripts/helpers.ps1
+++ b/fscps.tools/internal/scripts/helpers.ps1
@@ -241,35 +241,3 @@ function Expand-7zipArchive {
         Expand-Archive -Path $Path -DestinationPath "$DestinationPath" -Force
     }
 }
-
-function Get-MediaTypeByFilename {
-    [CmdletBinding()]
-    param(
-      [Parameter(Mandatory, ValueFromPipeline)]
-      [string[]] $Filename
-    )
-    begin {
-      # Download and parse the list of media types (MIME types) via
-      # https://github.com/jshttp/mime-db.
-      # NOTE:
-      #  * For better performance consider caching the JSON file.
-      #  * A fixed release is targeted, to ensure that future changes to the JSON
-      #    format do not break the command.
-      $mediaTypes = (
-        Invoke-RestMethod https://cdn.jsdelivr.net/gh/jshttp/mime-db@v1.53.0/db.json
-      ).psobject.Properties
-    }
-    process {
-      foreach ($name in $Filename) {
-        # Find the matching media type by filename extension.
-        $matchingMediaType =
-          $mediaTypes.Where(
-            { $_.Value.extensions -contains [IO.Path]::GetExtension($name).Substring(1) },
-            'First'
-          ).Name
-        # Use a fallback type, if no match was found.
-        if (-not $matchingMediaType) { $matchingMediaType = 'application/octet-stream' }
-        $matchingMediaType # output
-      }
-    }
-}

--- a/fscps.tools/internal/scripts/helpers.ps1
+++ b/fscps.tools/internal/scripts/helpers.ps1
@@ -84,7 +84,7 @@ function Validate-FSCModelCache {
                     $activeStorageConfigName = $_.Name
                 }
             }
-        } 
+        }
         $null = Set-FSCPSActiveAzureStorageConfig ModelStorage
     }
     process{
@@ -93,13 +93,13 @@ function Validate-FSCModelCache {
         $modelFileNameWithHash = "$($RepoOwner.ToLower())_$($RepoName.ToLower())_$($ModelName.ToLower())_$($BranchName.ToLower())_$($Version)_$($hash).7z".Replace(" ", "-")
         $modelFileNameWithoutHash = "$($RepoOwner.ToLower())_$($RepoName.ToLower())_$($ModelName.ToLower())_$($BranchName.ToLower())_$($Version)_*.7z".Replace(" ", "-")
         $modelFileNameGatedWithoutHash = "$($RepoOwner.ToLower())_$($RepoName.ToLower())_$($ModelName.ToLower())_*gated*_$($Version)_*.7z".Replace(" ", "-")
-        $modelFileNamePRWithoutHash = "$($RepoOwner.ToLower())_$($RepoName.ToLower())_$($ModelName.ToLower())_*refspull*_$($Version)_*.7z".Replace(" ", "-") 
-    
+        $modelFileNamePRWithoutHash = "$($RepoOwner.ToLower())_$($RepoName.ToLower())_$($ModelName.ToLower())_*refspull*_$($Version)_*.7z".Replace(" ", "-")
+
         Write-PSFMessage -Level Verbose -Message "Looking for $modelFileNameWithHash blob."
         $modelFile = Get-FSCPSAzureStorageFile -Name $modelFileNameWithHash
-    
+
         try
-        {       
+        {
             #Delete gated builds
             Invoke-FSCPSAzureStorageDelete -FileName $modelFileNameGatedWithoutHash
             Invoke-FSCPSAzureStorageDelete -FileName $modelFileNamePRWithoutHash
@@ -107,10 +107,10 @@ function Validate-FSCModelCache {
             {
                 Write-PSFMessage -Level Important -Message "Blob $modelFileNameWithHash found.The model $ModelName will be skipped for building."
                 $null = Invoke-FSCPSAzureStorageDownload -FileName $modelFileNameWithHash -Path $tempFolder -Force
-        
+
                 $modelFileTmpPath = (Join-Path $tempFolder $modelFileNameWithHash)
                 Expand-7zipArchive -Path $modelFileTmpPath -DestinationPath $modelRootPath
-                
+
                 return $true;
             }
             else {
@@ -121,26 +121,26 @@ function Validate-FSCModelCache {
 
                 return $false;
             }
-            
+
         }
         catch{
             return $false;
-        }        
+        }
     }
     end{
         if(-not [string]::IsNullOrEmpty($activeStorageConfigName)){
             Set-FSCPSActiveAzureStorageConfig $activeStorageConfigName
         }
-    }    
+    }
 }
 
 function Update-7ZipInstallation
 {
         # Modern websites require TLS 1.2
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        
+
         #requires -RunAsAdministrator
-        
+
         # Let's go directly to the website and see what it lists as the current version
         $BaseUri = "https://www.7-zip.org/"
         $BasePage = Invoke-WebRequest -Uri ( $BaseUri + 'download.html' ) -UseBasicParsing
@@ -152,10 +152,10 @@ function Update-7ZipInstallation
             # The most recent 'current' (non-beta/alpha) is listed at the top, so we only need the first.
             $ChildPath = $BasePage.Links | Where-Object { $_.href -like '*7z*.msi' } | Select-Object -First 1 | Select-Object -ExpandProperty href
         }
-        
+
         # Let's build the required download link
         $DownloadUrl = $BaseUri + $ChildPath
-        
+
         Write-Host "Downloading the latest 7-Zip to the temp folder"
         Invoke-WebRequest -Uri $DownloadUrl -OutFile "$env:TEMP\$( Split-Path -Path $DownloadUrl -Leaf )" | Out-Null
         Write-Host "Installing the latest 7-Zip"
@@ -248,10 +248,10 @@ function Get-MediaTypeByFilename {
       [Parameter(Mandatory, ValueFromPipeline)]
       [string[]] $Filename
     )
-    begin { 
+    begin {
       # Download and parse the list of media types (MIME types) via
       # https://github.com/jshttp/mime-db.
-      # NOTE: 
+      # NOTE:
       #  * For better performance consider caching the JSON file.
       #  * A fixed release is targeted, to ensure that future changes to the JSON
       #    format do not break the command.
@@ -262,9 +262,9 @@ function Get-MediaTypeByFilename {
     process {
       foreach ($name in $Filename) {
         # Find the matching media type by filename extension.
-        $matchingMediaType = 
+        $matchingMediaType =
           $mediaTypes.Where(
-            { $_.Value.extensions -contains [IO.Path]::GetExtension($name).Substring(1) }, 
+            { $_.Value.extensions -contains [IO.Path]::GetExtension($name).Substring(1) },
             'First'
           ).Name
         # Use a fallback type, if no match was found.

--- a/fscps.tools/internal/scripts/helpers.ps1
+++ b/fscps.tools/internal/scripts/helpers.ps1
@@ -256,7 +256,7 @@ function Get-MediaTypeByFilename {
       #  * A fixed release is targeted, to ensure that future changes to the JSON
       #    format do not break the command.
       $mediaTypes = (
-        Invoke-RestMethod https://cdn.jsdelivr.net/gh/jshttp/mime-db@v1.52.0/db.json
+        Invoke-RestMethod https://cdn.jsdelivr.net/gh/jshttp/mime-db@v1.53.0/db.json
       ).psobject.Properties
     }
     process {


### PR DESCRIPTION
This pull request refactors Invoke-FSCPSAzureStorageUpload to wrap a call to Invoke-D365AzureStorageUpload. [[1]](diffhunk://#diff-2928a74e104d83a657d9f4f8f905fd4461445d0ced13762f904c6d9fad0c7923L70-L90) [[2]](diffhunk://#diff-2928a74e104d83a657d9f4f8f905fd4461445d0ced13762f904c6d9fad0c7923L101-L170)

As part of the changes, I noticed that the logic to determine the MIME type of the file to upload is not working. The reason was that the Get-MediaFileTypeByFilename function from the helpers.ps1 file could not be found, as it was not loaded. Instead of adding logic to load helpers.ps1 in Invoke-FSCPSAzureStorageUpload, I moved it to its own internal function. This way, it gets loaded automatically like the other internal functions.

I also improved Get-MediaFileTypeByFilename by caching the db.json file with the media types that gets downloaded. It is stored in C:\temp\fscps.tools\mediatypes\mediatypes.json.