### PR TITLE
Refactor Invoke-FSCPSAzureStorageDownload

### DIFF
--- a/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
+++ b/fscps.tools/functions/invoke-fscpsazurestorageupload.ps1
@@ -114,8 +114,8 @@ function Invoke-FSCPSAzureStorageUpload {
 
                 Write-PSFMessage -Level Verbose -Message "Content Type is automatically set to value: $ContentType"
             }
-            $params = Get-ParameterValue
-            $params["ContentType"] = $ContentType
+            $params = Get-ParameterValue |
+                ConvertTo-PSFHashtable -ReferenceCommand Invoke-D365AzureStorageUpload -ReferenceParameterSetName $PSCmdlet.ParameterSetName
 
             Invoke-D365AzureStorageUpload @params
         }

--- a/fscps.tools/tests/functions/Get-FSCPSAzureStorageFile.Tests.ps1
+++ b/fscps.tools/tests/functions/Get-FSCPSAzureStorageFile.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe "Get-FSCPSAzureStorageFile Unit Tests" -Tag "Unit" {
+Describe "Get-FSCPSAzureStorageFile Unit Tests" -Tag "Unit" {
 	BeforeAll {
 		# Place here all things needed to prepare for the tests
 	}
@@ -81,13 +81,13 @@
 			$parameter.Name | Should -Be 'DestinationPath'
 			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
-			$parameter.ParameterSets.Keys | Should -Be 'Default'
-			$parameter.ParameterSets.Keys | Should -Contain 'Default'
-			$parameter.ParameterSets['Default'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['Default'].Position | Should -Be -2147483648
-			$parameter.ParameterSets['Default'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['Default'].ValueFromPipelineByPropertyName | Should -Be $False
-			$parameter.ParameterSets['Default'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
 		It 'Should have the expected parameter Latest' {
 			$parameter = (Get-Command Get-FSCPSAzureStorageFile).Parameters['Latest']


### PR DESCRIPTION
This pull request refactors [`Invoke-FSCPSAzureStorageDownload`](diffhunk://#diff-1f6c8fcb9e2fc7dab1b90f497c99bd9fcdf85b85145876151c2c1f02ee7c08d9L115-L184) into a wrapper around `Invoke-D365AzureStorageDownload`.

It also makes some improvements to [`Get-FSCPSAzureStorageFile`](diffhunk://#diff-bb0fcf826bb9cfe3c62e5641d41dbf4475f9f3d8f2c940e81c733b029f6858c6L90)[[1]](diffhunk://#diff-bb0fcf826bb9cfe3c62e5641d41dbf4475f9f3d8f2c940e81c733b029f6858c6L90) [[2]](diffhunk://#diff-bb0fcf826bb9cfe3c62e5641d41dbf4475f9f3d8f2c940e81c733b029f6858c6L106-R106) [[3]](diffhunk://#diff-bb0fcf826bb9cfe3c62e5641d41dbf4475f9f3d8f2c940e81c733b029f6858c6L120-R130) [[4]](diffhunk://#diff-bb0fcf826bb9cfe3c62e5641d41dbf4475f9f3d8f2c940e81c733b029f6858c6L140-L142) and [`Invoke-FSCPSAzureStorageUpload`](diffhunk://#diff-2928a74e104d83a657d9f4f8f905fd4461445d0ced13762f904c6d9fad0c7923L117-R118).